### PR TITLE
Add Semver Constrained

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "illuminate/support": "~5|~6|~7|~8",
     "league/flysystem": "^1.0",
     "nesbot/carbon": "^1.0|^2.0",
-    "composer/semver": "^1.4",
+    "composer/semver": "^1.4|^3.0",
     "alek13/slack": "~1.7",
     "geerlingguy/ping": "^1.1"
   },


### PR DESCRIPTION
`composer/composer` version 2.x requires `composer/semver ^3.0` but this package requires `^1.4` of the semver package. 

I looks like it's only used in the `CorrectPhpVersionInstalled` check. But don't know if it would have any impact on custom checks created by people. So it may be beter to tag it as a major release?