### PR TITLE
Fix Laravel 9.x bug

### DIFF
--- a/src/Senders/Mail.php
+++ b/src/Senders/Mail.php
@@ -43,12 +43,12 @@ class Mail implements Sender
                                 ->subject($subject)
                                 ->from($from)
                                 ->to($email)
-                                ->setBody($body, 'text/html');
+                                ->html($body);
                         } else {
                             $message
                                 ->subject($subject)
                                 ->to($email)
-                                ->setBody($body, 'text/html');
+                                ->html($body);
                         }
                     });
                 }


### PR DESCRIPTION
`setBody()` expects `Symfony\Component\Mime\Part\AbstractPart` 

The upgrade docs of Laravel say to just use the `html()` method.
https://laravel.com/docs/9.x/upgrade#symfony-mailer